### PR TITLE
add node IDs to certain nodes of interest

### DIFF
--- a/src/hook/CreatorLayer.cpp
+++ b/src/hook/CreatorLayer.cpp
@@ -17,6 +17,7 @@ class $modify(RLHCreatorLayer, CreatorLayer) {
             lbButtonSpr->setScale(1.2f);
             auto lbButton = CCMenuItemSpriteExtra::create(
                 lbButtonSpr, this, menu_selector(RLHCreatorLayer::onRatedLayoutLayer));
+            lbButton->setID("rated-layouts-button"_spr);
             bottomLeftMenu->addChild(lbButton);
             bottomLeftMenu->updateLayout();
             return true;

--- a/src/hook/EndLevelLayer.cpp
+++ b/src/hook/EndLevelLayer.cpp
@@ -259,6 +259,7 @@ class $modify(EndLevelLayer) {
                                        2});
                               bigStarSprite->setOpacity(0);
                               bigStarSprite->setScale(1.2f);
+                              bigStarSprite->setID(isPlat ? "rl-planet-reward-sprite" : "rl-star-reward-sprite");
                               endLayerRef->m_mainLayer->addChild(bigStarSprite);
 
                               // star animation lol
@@ -276,6 +277,7 @@ class $modify(EndLevelLayer) {
                               difficultyLabel->setPosition(
                                   {-5, bigStarSprite->getContentSize().height / 2});
                               difficultyLabel->setAnchorPoint({1.0f, 0.5f});
+                              difficultyLabel->setID(isPlat ? "rl-planet-reward-label" : "rl-star-reward-label");
                               bigStarSprite->addChild(difficultyLabel);
 
                               // never used this before but its fancy

--- a/src/hook/GauntletSelectLayer.cpp
+++ b/src/hook/GauntletSelectLayer.cpp
@@ -15,6 +15,7 @@ class $modify(RLHookGauntletSelectLayer, GauntletSelectLayer) {
                   auto gauntletBtnSpr = AccountButtonSprite::create(gauntletSpr, AccountBaseColor::Blue, AccountBaseSize::Normal);
                   auto gauntletBtn = CCMenuItemSpriteExtra::create(
                       gauntletBtnSpr, this, menu_selector(RLHookGauntletSelectLayer::onGauntletButtonClick));
+                  gauntletBtn->setID("rated-layouts-gauntlets-button"_spr);
                   topRight->addChild(gauntletBtn);
                   topRight->updateLayout();
             }

--- a/src/hook/GjGarageLayer.cpp
+++ b/src/hook/GjGarageLayer.cpp
@@ -117,6 +117,7 @@ class $modify(GJGarageLayer) {
                             m_fields->storedStars, 0.54f);
 
                         m_fields->starsValue = starsValue;
+                        starsValue->setID("rl-stars-value");
                         m_fields->statMenu->addChild(starsValue);
 
                         auto planetSprite = CCSprite::create("RL_planetMed.png"_spr);
@@ -124,6 +125,7 @@ class $modify(GJGarageLayer) {
                             "planets-collected"_spr, planetSprite,
                             planets, 0.54f);
                         m_fields->planetsValue = planetsValue;
+                        planetsValue->setID("rl-planets-value");
                         m_fields->statMenu->addChild(planetsValue);
 
                         auto coinsSprite = CCSprite::create("RL_BlueCoinSmall.png"_spr);
@@ -131,6 +133,7 @@ class $modify(GJGarageLayer) {
                             "coins-collected"_spr, coinsSprite,
                             coins, 0.54f);
                         m_fields->coinsValue = coinsValue;
+                        coinsValue->setID("rl-coins-value");
                         m_fields->statMenu->addChild(coinsValue);
 
                         // call updateLayout if available

--- a/src/hook/InfoLayer.cpp
+++ b/src/hook/InfoLayer.cpp
@@ -50,6 +50,7 @@ class $modify(RLLInfoLayer, InfoLayer) {
                               auto reportButton = CCMenuItemSpriteExtra::create(
                                   reportButtonSpr, layerRef, menu_selector(RLLInfoLayer::onReportButton));
 
+                              reportButton->setID("rated-layouts-report-button"_spr);
                               auto vanillaReportButton = layerRef->getChildByIDRecursive("report-button");
                               auto mainMenu = layerRef->getChildByIDRecursive("main-menu");
                               if (vanillaReportButton) {


### PR DESCRIPTION
 tried to respect your custom "rl-" prefix as best as i could wherever i could, but i used `_spr` suffix in buttons specifically since those tend to be accessed the most often by other mods and omitting the mod ID prefix from it is a recipe for disaster.

no preexisting node IDs were changed